### PR TITLE
fuzzy string matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Django==2.2.12
 django-tinymce==2.8.0
 elasticsearch==5.5.3
 Pillow==7.1.1
-psycopg2==2.8.5
 pyodbc==4.0.30
 pytz==2019.1
 sqlparse==0.3.0

--- a/search/views.py
+++ b/search/views.py
@@ -657,7 +657,8 @@ def build_es_query(search_term, fields):
 					"match" : {
 						k : {
 							"query" : v,
-							"operator" : "and"
+							"operator" : "and",
+							"fuzziness": "AUTO"
 						}
 					}
 				})
@@ -679,7 +680,8 @@ def build_es_query(search_term, fields):
 					  "displaytext" : {
 						 "query" : search_term,
 						 "operator" : "and",
-						 "boost" : 2
+						 "boost" : 2,
+						 "fuzziness": "AUTO"
 					  }
 				   }
 				},
@@ -687,7 +689,8 @@ def build_es_query(search_term, fields):
 					"match" : {
 					   "_all" : {
 						"query" : search_term,
-						"operator" : "and"
+						"operator" : "and",
+						"fuzziness": "AUTO"
 					   }
 					}
 				}


### PR DESCRIPTION
Added fuzzy parameter to elastic search. From the documentation: If the length of the search is <3 the maximum Levenshtein distance allowed will be 0 (i.e. only exact matches) If the length of the search is 3-5 the maximum Levenshtein distance allowed will be 1 (off by 1 character). If the length of the search is >5 the maximum Levenshtein distance allowed will be 2.